### PR TITLE
Sprint 7/issue#72 implement property filtering by city

### DIFF
--- a/src/components/Explore/PropertyCard.tsx
+++ b/src/components/Explore/PropertyCard.tsx
@@ -15,7 +15,7 @@ import Moment from 'moment'
 interface PropertyCardProps {
   property: {
     images: string[];
-    location: string;
+    city: string;
     rating: number;
     propertyName: string;
     avaliabilityDates: Date;
@@ -31,10 +31,6 @@ const renderItem = ({item}: {item: string}) => (
 );
 
 const PropertyCard: React.FC<PropertyCardProps> = ({property, onPress}) => {
-  const timestamp = property.avaliabilityDates;
-  const date = new Date(timestamp.seconds * 1000);
-  const formattedDate = Moment(date).format('MMM D, YYYY');
-  //console.log(property.images)
 
   return (
     <TouchableWithoutFeedback onPress={onPress}>
@@ -52,11 +48,10 @@ const PropertyCard: React.FC<PropertyCardProps> = ({property, onPress}) => {
 
         <View style={styles.propertyInfo}>
           <View style={styles.propertyHeader}>
-            <Text style={styles.propertyLocation}>{property.location}</Text>
+            <Text style={styles.propertyLocation}>{property.city}</Text>
             <Rating rating={property.rating} />
           </View>
           <Text style={styles.propertyDescription}>{property.propertyName}</Text>
-          <Text style={styles.propertyDateAvailable}>{formattedDate}</Text>
 
           <Text style={styles.propertyPrice}>${property.price} por noche</Text>
         </View>

--- a/src/components/SelectCity/SelectLocation.tsx
+++ b/src/components/SelectCity/SelectLocation.tsx
@@ -1,21 +1,21 @@
-import {StyleSheet, Text, View} from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
-import {SelectList} from 'react-native-dropdown-select-list';
+import { SelectList } from 'react-native-dropdown-select-list';
 import city from '../../data/city.json';
 
-const SelectLocation = ({selectedCity}: {selectedCity: Function}) => {
+const SelectLocation = ({ title, selectedCity }: { title: string, selectedCity: Function }) => {
   return (
     <View>
-      <Text style={styles.title}>In which city do you want to search?</Text>
+      <Text style={styles.title}>{title}</Text>
       <SelectList
         setSelected={selectedCity}
         data={city}
         save="value"
         placeholder="Select a city"
-        boxStyles={{borderColor: '#DBDADA'}}
-        inputStyles={{color: '#444444'}}
-        dropdownStyles={{borderColor: '#DBDADA'}}
-        dropdownTextStyles={{color: '#444444'}}
+        boxStyles={{ borderColor: '#DBDADA' }}
+        inputStyles={{ color: '#444444' }}
+        dropdownStyles={{ borderColor: '#DBDADA' }}
+        dropdownTextStyles={{ color: '#444444' }}
       />
     </View>
   );

--- a/src/screens/Explore.tsx
+++ b/src/screens/Explore.tsx
@@ -4,6 +4,7 @@ import SearchBar from '../components/Explore/SearchBar';
 import CategoryButton from '../components/Explore/CategoryButton';
 import PropertyCard from '../components/Explore/PropertyCard';
 import firestore from '@react-native-firebase/firestore';
+import auth from '@react-native-firebase/auth';
 
 const Explore = ({ navigation }: any) => {
   const categories = [
@@ -25,11 +26,29 @@ const Explore = ({ navigation }: any) => {
   useEffect(() => {
     const fetchProperties = async () => {
       try {
+        const user = auth().currentUser;
+        if (!user) {
+          return;
+        }
+
+        const userDoc = await firestore()
+          .collection('users')
+          .doc(user.uid)
+          .get();
+
+        const userData = userDoc.data();
+        const defaultCity = userData?.defaultCity;
+
+        if (!defaultCity) {
+          return;
+        }
+
         const snapshot = await firestore()
           .collection('properties')
           .where('propertyType', '==', selectedCategory)
+          .where('city', '==', defaultCity)
           .get();
-        
+
         const fetchedProperties = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
         setProperties(fetchedProperties);
       } catch (error) {

--- a/src/screens/HostMode.tsx
+++ b/src/screens/HostMode.tsx
@@ -18,6 +18,8 @@ import firestore from '@react-native-firebase/firestore';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import {Picker as SelectPicker} from '@react-native-picker/picker';
 import {firebase} from '@react-native-firebase/auth';
+import SelectLocation from '../components/SelectCity/SelectLocation';
+
 
 const HostModeScreen: React.FC = ({navigation}: any) => {
   const [guests, setGuests] = React.useState(0);
@@ -25,7 +27,8 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
   const [beds, setBeds] = React.useState(0);
   const [bathrooms, setBathrooms] = React.useState(0);
   const [propertyName, setPropertyName] = React.useState('');
-  const [propertyLocation, setPropertyLocation] = React.useState('');
+  const [selectedCity, setSelectedCity] = React.useState('');
+  const [propertyAdress, setPropertyAdress] = React.useState('');
   const [propertyDescription, setPropertyDescription] = React.useState('');
   const [propertyImages, setPropertyImages] = React.useState<string[]>([]);
   const [price, setPrice] = React.useState<number | undefined>();
@@ -89,7 +92,8 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
   const handleAddProperty = async () => {
     if (
       !propertyName ||
-      !propertyLocation ||
+      !propertyAdress ||
+      !selectedCity ||
       guests <= 0 ||
       bedrooms <= 0 ||
       beds <= 0 ||
@@ -107,7 +111,8 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
     try {
       const propertyRef = await firestore().collection('properties').add({
         propertyName: propertyName,
-        location: propertyLocation,
+        propertyAdress: propertyAdress,
+        city: selectedCity,
         guests: guests,
         bedrooms: bedrooms,
         beds: beds,
@@ -133,7 +138,8 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
       await propertyRef.update({images: imageUrls});
 
       setPropertyName('');
-      setPropertyLocation('');
+      setPropertyAdress('');
+      setSelectedCity('');
       setGuests(0);
       setBedrooms(0);
       setBeds(0);
@@ -166,15 +172,25 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
               placeholder="Property name"
               placeholderTextColor={'#7C7C7C'}
             />
+
           </View>
 
           <View style={styles.inputWrapper}>
             <TextInput
               style={styles.input}
-              value={propertyLocation}
-              onChangeText={setPropertyLocation}
-              placeholder="Property location"
+              value={propertyAdress}
+              onChangeText={setPropertyAdress}
+              placeholder="Property Adress"
               placeholderTextColor={'#7C7C7C'}
+            />
+          </View>
+
+          <View style={styles.inputWrapper}>
+            <SelectLocation
+              title="Select the property city"
+              selectedCity={val => {
+                setSelectedCity(val);
+              }}
             />
           </View>
 

--- a/src/screens/HostMode.tsx
+++ b/src/screens/HostMode.tsx
@@ -20,7 +20,6 @@ import {Picker as SelectPicker} from '@react-native-picker/picker';
 import {firebase} from '@react-native-firebase/auth';
 import SelectLocation from '../components/SelectCity/SelectLocation';
 
-
 const HostModeScreen: React.FC = ({navigation}: any) => {
   const [guests, setGuests] = React.useState(0);
   const [bedrooms, setBedrooms] = React.useState(0);
@@ -33,7 +32,6 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
   const [propertyImages, setPropertyImages] = React.useState<string[]>([]);
   const [price, setPrice] = React.useState<number | undefined>();
   const [isDatePickerVisible, setDatePickerVisibility] = React.useState(false);
-  const [selectedDate, setSelectedDate] = React.useState<Date | null>(null);
   const [propertyType, setPropertyType] = React.useState<string>('');
   const userId = firebase.auth().currentUser?.uid || '';
 
@@ -84,11 +82,6 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
     setDatePickerVisibility(false);
   };
 
-  const handleConfirm = (date: Date) => {
-    setSelectedDate(date);
-    hideDatePicker();
-  };
-
   const handleAddProperty = async () => {
     if (
       !propertyName ||
@@ -118,7 +111,6 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
         beds: beds,
         bathrooms: bathrooms,
         description: propertyDescription,
-        avaliabilityDates: selectedDate,
         price: price,
         propertyType: propertyType,
         hostId: userId,
@@ -145,7 +137,6 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
       setBeds(0);
       setBathrooms(0);
       setPropertyDescription('');
-      setSelectedDate(null);
       setPrice(undefined);
       setPropertyImages([]);
 
@@ -267,22 +258,6 @@ const HostModeScreen: React.FC = ({navigation}: any) => {
             />
             <View style={styles.line} />
           </View>
-
-          <TouchableOpacity style={styles.addButton} onPress={showDatePicker}>
-            <Text style={styles.addButtonText}>
-              {selectedDate
-                ? selectedDate.toLocaleDateString()
-                : 'Select Availability Dates'}
-            </Text>
-            <Icon name="calendar" size={30} color="gray" />
-          </TouchableOpacity>
-
-          <DateTimePickerModal
-            isVisible={isDatePickerVisible}
-            mode="date"
-            onConfirm={handleConfirm}
-            onCancel={hideDatePicker}
-          />
 
           <TouchableOpacity style={styles.addButton} onPress={handleAddImages}>
             <Text style={styles.addButtonText}>Add Images</Text>

--- a/src/screens/HostModePropertiesList.tsx
+++ b/src/screens/HostModePropertiesList.tsx
@@ -32,7 +32,7 @@ import IconDots from 'react-native-vector-icons/Entypo';
       <Text style={styles.title}>My Properties</Text>
       <ScrollView>
         {properties.map((property, index) => {
-              const details = `Guest: ${property.guests} | Bedrooms: ${property.bedrooms} | Beds: ${property.beds} | Bathrooms: ${property.bathrooms}`;
+              const details = `Guest: ${property.guests} · Bedrooms: ${property.bedrooms} · Beds: ${property.beds} · Bathrooms: ${property.bathrooms}`;
               const showOptions = (index : number) => {setActiveOptions(activeOptions === index ? null : index)};
               const editProperty: () => void = () => {navigation.navigate('HostModeUpdateProperties', { property: property });}
               //const editProperty: () => void = () => {console.log(property.avaliabilityDates)}
@@ -66,7 +66,7 @@ import IconDots from 'react-native-vector-icons/Entypo';
               />
               <View style={styles.propertyContainer}>
                 <Text style={styles.name}>{property.propertyName}</Text>
-                <Text style={styles.location}>{property.location}</Text>
+                <Text style={styles.location}>{property.propertyAdress}, {property.city}</Text>
                 <Text numberOfLines={1} style={styles.details}>{details}</Text>
               </View>
               <View>

--- a/src/screens/HostModeUpdateProperties.tsx
+++ b/src/screens/HostModeUpdateProperties.tsx
@@ -19,13 +19,15 @@ import firestore from '@react-native-firebase/firestore';
 import DateTimePickerModal from 'react-native-modal-datetime-picker';
 import {Picker as SelectPicker} from '@react-native-picker/picker';
 import {firebase} from '@react-native-firebase/auth';
+import SelectLocation from '../components/SelectCity/SelectLocation';
 
 const HostModeUpdateProperties: React.FC = ({route}: any) => {
   const navigation = useNavigation();
   const {property} = route.params;
 
   const [propertyName1, setPropertyName] = React.useState(property.propertyName);
-  const [propertyLocation1, setPropertyLocation] = React.useState(property.location);
+  const [propertyAdress1, setPropertyAdress] = React.useState(property.propertyAdress);
+  const [selectedCity, setSelectedCity] = React.useState(property.city);
   const [guests1, setGuests] = React.useState(property.guests);
   const [bedrooms1, setBedrooms] = React.useState(property.bedrooms);
   const [beds1, setBeds] = React.useState(property.beds);
@@ -95,7 +97,8 @@ const HostModeUpdateProperties: React.FC = ({route}: any) => {
   const handleUpdateProperty = async () => {
     if (
       !propertyName1 ||
-      !propertyLocation1 ||
+      !propertyAdress1 ||
+      !selectedCity ||
       guests1 <= 0 ||
       bedrooms1 <= 0 ||
       beds1 <= 0 ||
@@ -114,7 +117,8 @@ const HostModeUpdateProperties: React.FC = ({route}: any) => {
       const propertyRef = firestore().collection('properties').doc(property.id);
       await propertyRef.update({
         propertyName: propertyName1,
-        location: propertyLocation1,
+        propertyAdress: propertyAdress1,
+        city: selectedCity,
         guests: guests1,
         bedrooms: bedrooms1,
         beds: beds1,
@@ -137,7 +141,7 @@ const HostModeUpdateProperties: React.FC = ({route}: any) => {
        });
 
       setPropertyName('');
-      setPropertyLocation('');
+      setPropertyAdress('');
       setGuests(0);
       setBedrooms(0);
       setBeds(0);
@@ -146,6 +150,7 @@ const HostModeUpdateProperties: React.FC = ({route}: any) => {
       setSelectedDate(null);
       setPrice(undefined);
       setPropertyImages([]);
+      setSelectedCity('');
 
       // Mostrar una alerta de éxito al usuario
       Alert.alert('Success', 'Property updated successfully!');
@@ -175,10 +180,19 @@ const HostModeUpdateProperties: React.FC = ({route}: any) => {
           <View style={styles.inputWrapper}>
             <TextInput
               style={styles.input}
-              value={propertyLocation1}
-              onChangeText={setPropertyLocation}
+              value={propertyAdress1}
+              onChangeText={setPropertyAdress}
               placeholder="Property location"
               placeholderTextColor={'#7C7C7C'}
+            />
+          </View>
+
+          <View style={styles.inputWrapper}>
+            <SelectLocation
+              title="Select the property city"
+              selectedCity={val => {
+                setSelectedCity(val);
+              }}
             />
           </View>
 

--- a/src/screens/Profile.tsx
+++ b/src/screens/Profile.tsx
@@ -6,8 +6,6 @@ import auth from '@react-native-firebase/auth'
 import firestore from '@react-native-firebase/firestore';
 import OptionsButtons from '../components/ProfileScreenComponents/OptionsButtons';
 
-
-
 const Profile = ({navigation}: any) => {
   const [infoUser, setInfoUser] = useState({
     name: '',
@@ -88,7 +86,7 @@ const Profile = ({navigation}: any) => {
         icon="reorder-three-outline"
         text="Registered properties"
         onPress={() => {
-          isHost ? navigation.navigate('HostModePropertiesList') : navigation.navigate('HostModeInactive'); //Cambiar a screen Host mode.
+          infoUser.HostMode ? navigation.navigate('HostModePropertiesList') : navigation.navigate('HostModeInactive'); //Cambiar a screen Host mode.
         }}
       />
       <View style={styles.logoutContainer}>

--- a/src/screens/PropertyDetails.tsx
+++ b/src/screens/PropertyDetails.tsx
@@ -80,9 +80,9 @@ const PropertyDetailsScreen: React.FC = ({ route }: any) => {
         </View>
         <View style={styles.propertyInfo}>
           <Text style={styles.propertyName}>{property.propertyName}</Text>
-          <Text style={styles.propertyLocation}>{property.location}</Text>
+          <Text style={styles.propertyLocation}>{property.propertyAdress}, {property.city}</Text>
           <Text style={styles.propertyDetails}>
-            Guests: {property.guests} | Bedrooms: {property.bedrooms} | Beds: {property.beds} | Bathrooms: {property.bathrooms}
+            Guests: {property.guests} · Bedrooms: {property.bedrooms} · Beds: {property.beds} · Bathrooms: {property.bathrooms}
           </Text>
           <TouchableOpacity onPress={handleRatingPress}>
             <RatingBox averageRating={averageRating} totalReviews={totalReviews} />

--- a/src/screens/ReviewScreen.tsx
+++ b/src/screens/ReviewScreen.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, ScrollView } from 'react-native';
-import ReviewForm from '../components/Review/ReviewForm'; // Importa el componente de formulario de reseña
-import ReviewItem from '../components/Review/ReviewItem'; // Importa el componente de ítem de reseña
+import ReviewForm from '../components/Review/ReviewForm'; 
+import ReviewItem from '../components/Review/ReviewItem'; 
 import { useNavigation, useRoute } from '@react-navigation/native';
 import firestore from '@react-native-firebase/firestore';
 
@@ -9,7 +9,6 @@ const ReviewScreen: React.FC = ({ route }: any) => {
   const navigation = useNavigation();
   const { property } = route.params;
 
-  // Fetch reviews for the property from Firestore
   const [reviews, setReviews] = React.useState<any[]>([]);
   React.useEffect(() => {
     const fetchReviews = async () => {

--- a/src/screens/SelectCity.tsx
+++ b/src/screens/SelectCity.tsx
@@ -37,6 +37,7 @@ export default function SelectCity() {
           be found here.
         </Text>
         <SelectLocation
+          title='In which city do you want to search?'
           selectedCity={val => {
             setSelectedCity(val);
           }}


### PR DESCRIPTION
# Description

Implement Default City Filter in Explore Screen

This pull request implements a new feature in the Explore screen to filter properties based on the default city of the current user. The changes are summarized as follows:

- Added functionality to fetch the default city of the current user from Firebase Firestore.
- Utilized the Firebase Auth module to get the current user's ID and query the Firestore database for the user document.
- Extracted the default city value from the user document and stored it for filtering properties.
- Modified the existing logic to fetch properties to include filtering by the default city.
- Added an additional where clause to the Firestore query to filter properties based on the selected category and the default city obtained from the user's profile.